### PR TITLE
Use new class to generate more easily doctrine annotations

### DIFF
--- a/src/Comment.php
+++ b/src/Comment.php
@@ -57,12 +57,23 @@ class Comment
         return false;
     }
 
-    public function addAnnotation(string $annotation, string $content = '', bool $replaceExisting = true): self
+    /**
+     * @param string $annotation
+     * @param mixed $content
+     * @param bool $replaceExisting
+     * @return Comment
+     */
+    public function addAnnotation(string $annotation, $content = null, bool $replaceExisting = true, bool $explicitNull = false): self
     {
         if ($replaceExisting === true) {
             $this->removeAnnotation($annotation);
         }
         $annotation = ltrim($annotation, '@');
+        if ($explicitNull === true && $content === null) {
+            $content = '(null)';
+        } else {
+            $content = DoctrineAnnotationDumper::exportValues($content);
+        }
         $this->comment .= "\n@".$annotation.$content;
         return $this;
     }

--- a/src/DoctrineAnnotationDumper.php
+++ b/src/DoctrineAnnotationDumper.php
@@ -1,0 +1,80 @@
+<?php
+
+
+namespace TheCodingMachine\FluidSchema;
+
+
+use function addslashes;
+use function array_map;
+use function implode;
+use function is_array;
+use function is_numeric;
+use function is_string;
+use function var_export;
+
+class DoctrineAnnotationDumper
+{
+    /**
+     * Write a string representing the parameter passed in.
+     * @param mixed $item
+     */
+    public static function exportValues($item): string
+    {
+        if ($item === null) {
+            return '';
+        }
+        if ($item === []) {
+            return '({})';
+        }
+        return '('.self::innerExportValues($item, true).')';
+    }
+
+    private static function innerExportValues($item, bool $first): string
+    {
+        if ($item === null) {
+            return 'null';
+        }
+        if (is_string($item)) {
+            return '"'.addslashes($item).'"';
+        }
+        if (is_numeric($item)) {
+            return $item;
+        }
+        if (is_bool($item)) {
+            return $item ? 'true' : 'false';
+        }
+        if (is_array($item)) {
+            if (self::isAssoc($item)) {
+                if ($first) {
+                    array_walk($item, function(&$value, $key) {
+                        $value = $key.' = '.self::innerExportValues($value, false);
+                    });
+                } else {
+                    array_walk($item, function(&$value, $key) {
+                        $value = '"'.addslashes($key).'":'.self::innerExportValues($value, false);
+                    });
+                }
+                $result = implode(', ', $item);
+                if (!$first) {
+                    $result = '{'.$result.'}';
+                }
+                return $result;
+            } else {
+                array_walk($item, function(&$value, $key) {
+                    $value = self::innerExportValues($value, false);
+                });
+                $result = implode(', ', $item);
+                if (!$first) {
+                    $result = '{'.$result.'}';
+                }
+                return $result;
+            }
+        }
+        throw new \RuntimeException('Cannot serialize value in Doctrine annotation.');
+    }
+
+    private static function isAssoc(array $arr): bool
+    {
+        return array_keys($arr) !== range(0, count($arr) - 1);
+    }
+}

--- a/src/TdbmFluidColumnGraphqlOptions.php
+++ b/src/TdbmFluidColumnGraphqlOptions.php
@@ -21,7 +21,7 @@ class TdbmFluidColumnGraphqlOptions
 
     public function fieldName(string $name): self
     {
-        $this->addAnnotation('TheCodingMachine\\GraphQLite\\Annotations\\Field', '(name="'.addslashes($name).'")');
+        $this->addAnnotation('TheCodingMachine\\GraphQLite\\Annotations\\Field', ['name'=>$name]);
         return $this;
     }
 
@@ -37,19 +37,25 @@ class TdbmFluidColumnGraphqlOptions
 
     public function right(string $rightName): self
     {
-        $this->addAnnotation('TheCodingMachine\\GraphQLite\\Annotations\\Right', '(name="'.addslashes($rightName).'")');
+        $this->addAnnotation('TheCodingMachine\\GraphQLite\\Annotations\\Right', ['name'=>$rightName]);
         return $this;
     }
 
     public function failWith($value): self
     {
-        $this->addAnnotation('TheCodingMachine\\GraphQLite\\Annotations\\FailWith', '('.var_export($value, true).')');
+        $this->addAnnotation('TheCodingMachine\\GraphQLite\\Annotations\\FailWith', $value, true, true);
         return $this;
     }
 
-    public function addAnnotation(string $annotation, string $content = '', bool $replaceExisting = true): self
+    /**
+     * @param string $annotation
+     * @param mixed $content
+     * @param bool $replaceExisting
+     * @return TdbmFluidColumnGraphqlOptions
+     */
+    public function addAnnotation(string $annotation, $content = null, bool $replaceExisting = true, bool $explicitNull = false): self
     {
-        $this->tdbmFluidColumnOptions->addAnnotation($annotation, $content, $replaceExisting);
+        $this->tdbmFluidColumnOptions->addAnnotation($annotation, $content, $replaceExisting, $explicitNull);
         return $this;
     }
 

--- a/src/TdbmFluidColumnOptions.php
+++ b/src/TdbmFluidColumnOptions.php
@@ -123,9 +123,15 @@ class TdbmFluidColumnOptions
         return $this;
     }
 
-    public function addAnnotation(string $annotation, string $content = '', bool $replaceExisting = true): self
+    /**
+     * @param string $annotation
+     * @param mixed $content
+     * @param bool $replaceExisting
+     * @return TdbmFluidColumnOptions
+     */
+    public function addAnnotation(string $annotation, $content = null, bool $replaceExisting = true, bool $explicitNull = false): self
     {
-        $comment = $this->getComment()->addAnnotation($annotation, $content, $replaceExisting);
+        $comment = $this->getComment()->addAnnotation($annotation, $content, $replaceExisting, $explicitNull);
         $this->saveComment($comment);
         return $this;
     }

--- a/src/TdbmFluidJunctionTableGraphqlOptions.php
+++ b/src/TdbmFluidJunctionTableGraphqlOptions.php
@@ -36,19 +36,25 @@ class TdbmFluidJunctionTableGraphqlOptions
 
     public function right(string $rightName): self
     {
-        $this->addAnnotation('TheCodingMachine\\GraphQLite\\Annotations\\Right', '(name="'.addslashes($rightName).'")');
+        $this->addAnnotation('TheCodingMachine\\GraphQLite\\Annotations\\Right', ['name'=>$rightName]);
         return $this;
     }
 
     public function failWith($value): self
     {
-        $this->addAnnotation('TheCodingMachine\\GraphQLite\\Annotations\\FailWith', '('.var_export($value, true).')');
+        $this->addAnnotation('TheCodingMachine\\GraphQLite\\Annotations\\FailWith', $value, true, true);
         return $this;
     }
 
-    public function addAnnotation(string $annotation, string $content = '', bool $replaceExisting = true): self
+    /**
+     * @param string $annotation
+     * @param mixed $content
+     * @param bool $replaceExisting
+     * @return TdbmFluidJunctionTableGraphqlOptions
+     */
+    public function addAnnotation(string $annotation, $content = null, bool $replaceExisting = true, bool $explicitNull = false): self
     {
-        $this->tdbmFluidTable->addAnnotation($annotation, $content, $replaceExisting);
+        $this->tdbmFluidTable->addAnnotation($annotation, $content, $replaceExisting, $explicitNull);
         return $this;
     }
 

--- a/src/TdbmFluidTable.php
+++ b/src/TdbmFluidTable.php
@@ -73,7 +73,7 @@ class TdbmFluidTable
         }
         $this->fluidTable->uuid();
 
-        $this->column('uuid')->guid()->addAnnotation('UUID', '("'.$version.'")');
+        $this->column('uuid')->guid()->addAnnotation('UUID', $version);
         return $this;
     }
 
@@ -97,7 +97,7 @@ class TdbmFluidTable
      */
     public function customBeanName(string $beanName): TdbmFluidTable
     {
-        $this->addAnnotation('Bean', '(name="'.addslashes($beanName).'")');
+        $this->addAnnotation('Bean', ['name'=>$beanName]);
         return $this;
     }
 
@@ -124,9 +124,15 @@ class TdbmFluidTable
         return $this;
     }
 
-    public function addAnnotation(string $annotation, string $content = '', bool $replaceExisting = true): self
+    /**
+     * @param string $annotation
+     * @param mixed $content
+     * @param bool $replaceExisting
+     * @return TdbmFluidTable
+     */
+    public function addAnnotation(string $annotation, $content = null, bool $replaceExisting = true, bool $explicitNull = false): self
     {
-        $comment = $this->getComment()->addAnnotation($annotation, $content, $replaceExisting);
+        $comment = $this->getComment()->addAnnotation($annotation, $content, $replaceExisting, $explicitNull);
         $this->saveComment($comment);
         return $this;
     }

--- a/tests/CommentTest.php
+++ b/tests/CommentTest.php
@@ -39,7 +39,7 @@ Foo
 @Yop
 EOF
         );
-        $comment->addAnnotation('Yop', '(true)');
+        $comment->addAnnotation('Yop', true);
         $this->assertSame(<<<EOF
 Foo
 @Yop(true)

--- a/tests/DoctrineAnnotationDumperTest.php
+++ b/tests/DoctrineAnnotationDumperTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace TheCodingMachine\FluidSchema;
+
+use PHPUnit\Framework\TestCase;
+
+class DoctrineAnnotationDumperTest extends TestCase
+{
+
+    public function testExportValues()
+    {
+        $this->assertSame('', DoctrineAnnotationDumper::exportValues(null));
+        $this->assertSame('({})', DoctrineAnnotationDumper::exportValues([]));
+        $this->assertSame('("foo")', DoctrineAnnotationDumper::exportValues("foo"));
+        $this->assertSame('(foo = "bar")', DoctrineAnnotationDumper::exportValues(["foo"=>"bar"]));
+        $this->assertSame('(foo = {"bar":"baz", "baz":"bar"})', DoctrineAnnotationDumper::exportValues(["foo"=>["bar"=>"baz","baz"=>"bar"]]));
+    }
+}

--- a/tests/TdbmFluidColumnGraphqlOptionsTest.php
+++ b/tests/TdbmFluidColumnGraphqlOptionsTest.php
@@ -25,16 +25,16 @@ class TdbmFluidColumnGraphqlOptionsTest extends TestCase
                        ->right('CAN_EDIT')
                        ->failWith(null);
 
-        $this->assertSame("\n@TheCodingMachine\GraphQLite\Annotations\Field(name=\"bar\")
+        $this->assertSame("\n@TheCodingMachine\GraphQLite\Annotations\Field(name = \"bar\")
 @TheCodingMachine\GraphQLite\Annotations\Logged
-@TheCodingMachine\GraphQLite\Annotations\Right(name=\"CAN_EDIT\")
-@TheCodingMachine\GraphQLite\Annotations\FailWith(NULL)", $schema->getTable('posts')->getColumn('foo')->getComment());
+@TheCodingMachine\GraphQLite\Annotations\Right(name = \"CAN_EDIT\")
+@TheCodingMachine\GraphQLite\Annotations\FailWith(null)", $schema->getTable('posts')->getColumn('foo')->getComment());
 
         $graphqlOptions->logged(false);
 
-        $this->assertSame("\n@TheCodingMachine\GraphQLite\Annotations\Field(name=\"bar\")
-@TheCodingMachine\GraphQLite\Annotations\Right(name=\"CAN_EDIT\")
-@TheCodingMachine\GraphQLite\Annotations\FailWith(NULL)", $schema->getTable('posts')->getColumn('foo')->getComment());
+        $this->assertSame("\n@TheCodingMachine\GraphQLite\Annotations\Field(name = \"bar\")
+@TheCodingMachine\GraphQLite\Annotations\Right(name = \"CAN_EDIT\")
+@TheCodingMachine\GraphQLite\Annotations\FailWith(null)", $schema->getTable('posts')->getColumn('foo')->getComment());
 
         $this->assertSame($columnOptions, $graphqlOptions->endGraphql());
 

--- a/tests/TdbmFluidJunctionTableGraphqlOptionsTest.php
+++ b/tests/TdbmFluidJunctionTableGraphqlOptionsTest.php
@@ -25,14 +25,14 @@ class TdbmFluidJunctionTableGraphqlOptionsTest extends TestCase
 
         $this->assertSame("\n@TheCodingMachine\GraphQLite\Annotations\Field
 @TheCodingMachine\GraphQLite\Annotations\Logged
-@TheCodingMachine\GraphQLite\Annotations\Right(name=\"CAN_EDIT\")
-@TheCodingMachine\GraphQLite\Annotations\FailWith(NULL)", $schema->getTable('posts_users')->getOptions()['comment']);
+@TheCodingMachine\GraphQLite\Annotations\Right(name = \"CAN_EDIT\")
+@TheCodingMachine\GraphQLite\Annotations\FailWith(null)", $schema->getTable('posts_users')->getOptions()['comment']);
 
         $graphqlOptions->logged(false);
 
         $this->assertSame("\n@TheCodingMachine\GraphQLite\Annotations\Field
-@TheCodingMachine\GraphQLite\Annotations\Right(name=\"CAN_EDIT\")
-@TheCodingMachine\GraphQLite\Annotations\FailWith(NULL)", $schema->getTable('posts_users')->getOptions()['comment']);
+@TheCodingMachine\GraphQLite\Annotations\Right(name = \"CAN_EDIT\")
+@TheCodingMachine\GraphQLite\Annotations\FailWith(null)", $schema->getTable('posts_users')->getOptions()['comment']);
 
         $this->assertSame($junctionTableOptions, $graphqlOptions->endGraphql());
     }

--- a/tests/TdbmFluidTableTest.php
+++ b/tests/TdbmFluidTableTest.php
@@ -120,7 +120,7 @@ class TdbmFluidTableTest extends TestCase
 
         $posts->customBeanName('Article');
 
-        $this->assertSame("\n@Bean(name=\"Article\")", $schema->getTable('posts')->getOptions()['comment']);
+        $this->assertSame("\n@Bean(name = \"Article\")", $schema->getTable('posts')->getOptions()['comment']);
     }
 
 


### PR DESCRIPTION
This PR introduces DoctrineAnnotationDumper that can be used to dump an annotation.