### PR TITLE
Changing method names to avoid confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ $posts = $db->table('posts')->graphqlType();
 
 // You can pass a new 'v1' or 'v4' parameter to uuid().
 // This will generate a @UUID TDBM annotation that will help TDBM autogenerate the UUID 
-$posts = $db->table('posts')->string('title')->graphql() // The column is a GraphQL field
+$posts = $db->table('posts')->string('title')->graphqlField() // The column is a GraphQL field
             ->fieldName('the_title') // Let's set the name of the field to a different value 
             ->logged() // The user must be logged to view the field
             ->right('CAN_EDIT') // The user must have the 'CAN_EDIT' right to view the field
             ->failWith(null) // If the user is not logged or has no right, let's serve 'null'
             ->endGraphql();
 
-$db->junctionTable('posts', 'users')->graphql(); // Expose the many-to-many relationship as a GraphQL field.
+$db->junctionTable('posts', 'users')->graphqlField(); // Expose the many-to-many relationship as a GraphQL field.
 ```

--- a/src/TdbmFluidColumnOptions.php
+++ b/src/TdbmFluidColumnOptions.php
@@ -102,7 +102,7 @@ class TdbmFluidColumnOptions
         return $this->tdbmFluidTable->column($name);
     }
 
-    public function graphql(): TdbmFluidColumnGraphqlOptions
+    public function graphqlField(): TdbmFluidColumnGraphqlOptions
     {
         $this->tdbmFluidTable->graphqlType();
         return new TdbmFluidColumnGraphqlOptions($this, $this->fluidColumn);

--- a/src/TdbmFluidJunctionTableOptions.php
+++ b/src/TdbmFluidJunctionTableOptions.php
@@ -20,7 +20,7 @@ class TdbmFluidJunctionTableOptions
         $this->tdbmFluidTable = $tdbmFluidTable;
     }
 
-    public function graphql(): TdbmFluidJunctionTableGraphqlOptions
+    public function graphqlField(): TdbmFluidJunctionTableGraphqlOptions
     {
         $this->tdbmFluidTable->addAnnotation('TheCodingMachine\\GraphQLite\\Annotations\\Field');
         return new TdbmFluidJunctionTableGraphqlOptions($this, $this->tdbmFluidTable);

--- a/tests/TdbmFluidColumnGraphqlOptionsTest.php
+++ b/tests/TdbmFluidColumnGraphqlOptionsTest.php
@@ -18,7 +18,7 @@ class TdbmFluidColumnGraphqlOptionsTest extends TestCase
         $column = $posts->column('foo');
         $columnOptions = $column->integer();
 
-        $graphqlOptions = $columnOptions->graphql();
+        $graphqlOptions = $columnOptions->graphqlField();
 
         $graphqlOptions->fieldName('bar')
                        ->logged(true)
@@ -45,11 +45,11 @@ class TdbmFluidColumnGraphqlOptionsTest extends TestCase
 
         $this->assertContains('@TheCodingMachine\GraphQLite\Annotations\Type', $schema->getTable('posts')->getOptions()['comment']);
 
-        $idColumn = $posts->id()->graphql();
+        $idColumn = $posts->id()->graphqlField();
         $this->assertContains('outputType = "ID"', $schema->getTable('posts')->getColumn('id')->getComment());
 
         $users = $fluid->table('users');
-        $uuidColumn = $users->uuid()->graphql();
+        $uuidColumn = $users->uuid()->graphqlField();
         $this->assertContains('outputType = "ID"', $schema->getTable('users')->getColumn('uuid')->getComment());
 
     }

--- a/tests/TdbmFluidJunctionTableGraphqlOptionsTest.php
+++ b/tests/TdbmFluidJunctionTableGraphqlOptionsTest.php
@@ -17,7 +17,7 @@ class TdbmFluidJunctionTableGraphqlOptionsTest extends TestCase
         $fluid->table('users')->uuid();
 
         $junctionTableOptions = $fluid->junctionTable('posts', 'users');
-        $graphqlOptions = $junctionTableOptions->graphql();
+        $graphqlOptions = $junctionTableOptions->graphqlField();
 
         $graphqlOptions->logged(true)
                        ->right('CAN_EDIT')

--- a/tests/TdbmFluidJunctionTableOptionsTest.php
+++ b/tests/TdbmFluidJunctionTableOptionsTest.php
@@ -16,7 +16,7 @@ class TdbmFluidJunctionTableOptionsTest extends TestCase
         $fluid->table('posts')->uuid();
         $fluid->table('users')->uuid();
 
-        $fluid->junctionTable('posts', 'users')->graphql();
+        $fluid->junctionTable('posts', 'users')->graphqlField();
 
         $this->assertSame("\n@TheCodingMachine\\GraphQLite\\Annotations\\Field", $schema->getTable('posts_users')->getOptions()['comment']);
     }


### PR DESCRIPTION
Renaming graphql() to graphqlField()